### PR TITLE
NT 3.1 fix

### DIFF
--- a/gdifix.c
+++ b/gdifix.c
@@ -14,7 +14,7 @@
 #define MAX_BITMAP_SIZE (16 * 1024 * 1024)  /* 16MB limit */
 
 HANDLE LoadImageFromFile(LPCSTR filename, UINT fuLoad) {
-#if(_MSC_VER > 900)
+#if 0//(_MSC_VER > 900)
     /* Use newer LoadImage API if available */
     return LoadImage(NULL, filename, IMAGE_BITMAP, 0, 0, fuLoad);
 #else

--- a/gdifix.h
+++ b/gdifix.h
@@ -27,7 +27,7 @@ HBITMAP convertTo8Bit(HBITMAP hSrcBitmap, HDC hdc, HPALETTE hSystemPalette);
 int validateTilesetFormat(HBITMAP hBitmap);
 
 /* CheckMenuRadioItem compatibility */
-#if(_MSC_VER < 1000)
+#if 1//(_MSC_VER < 1000)
     /* Simple fallback for older versions - uncheck all then check selected */
     #define CHECK_MENU_RADIO_ITEM(hmenu, first, last, check, flags) \
         { int __i; \

--- a/main.c
+++ b/main.c
@@ -3326,6 +3326,7 @@ void initializeGraphics(HWND hwnd) {
     int width;
     int height;
     BITMAPINFOHEADER bi;
+    BITMAPINFO binfo;
     HBITMAP hbmOld;
     char errorMsg[256];
     DWORD error;

--- a/main.c
+++ b/main.c
@@ -3364,7 +3364,7 @@ void initializeGraphics(HWND hwnd) {
     width = cxClient;
     height = cyClient;
 
-#if NEW32
+#ifdef NEW32
     /* Setup 8-bit DIB section for our drawing buffer */
     ZeroMemory(&bi, sizeof(BITMAPINFOHEADER));
     bi.biSize = sizeof(BITMAPINFOHEADER);
@@ -3381,17 +3381,14 @@ void initializeGraphics(HWND hwnd) {
     ZeroMemory(&bi, sizeof(BITMAPINFOHEADER));
     bi.biSize = sizeof(BITMAPINFOHEADER);
     bi.biWidth = width;
-    bi.biHeight = -height; /* Negative for top-down DIB */
+    bi.biHeight = height; /* We can't do top-down in win32s */
     bi.biPlanes = 1;
     bi.biBitCount = 8; /* 8 bits = 256 colors */
     bi.biCompression = BI_RGB;
 
-	hbmBuffer = CreateDIBitmap(hdc, 
-		&bi,				/* Pointer to BITMAPINFOHEADER */
-		CBM_INIT,			/* Initialize bitmap bits */
-		NULL,				/* Pointer to actual bitmap bits (if any) */
-		&binfo,				/* Pointer to BITMAPINFO */
-		DIB_RGB_COLORS);		/* Color usage */
+	hbmBuffer = CreateCompatibleBitmap(hdc, 
+		bi.biWidth,
+		bi.biHeight);
 #endif
 
     if (hbmBuffer == NULL) {
@@ -3696,7 +3693,7 @@ void resizeBuffer(int cx, int cy) {
         RealizePalette(hdc);
     }
 
-#if NEW32XX
+#ifdef NEW32
     ZeroMemory(&bi, sizeof(BITMAPINFOHEADER));
     bi.biSize = sizeof(BITMAPINFOHEADER);
     bi.biWidth = cx;
@@ -3712,17 +3709,14 @@ void resizeBuffer(int cx, int cy) {
     ZeroMemory(&bi, sizeof(BITMAPINFOHEADER));
     bi.biSize = sizeof(BITMAPINFOHEADER);
     bi.biWidth = cx;
-    bi.biHeight = -cy; /* Negative for top-down DIB */
+    bi.biHeight = cy; /* We can't do top-down in win32s */
     bi.biPlanes = 1;
     bi.biBitCount = 8; /* 8 bits = 256 colors */
     bi.biCompression = BI_RGB;
 
-	hbmNew = CreateDIBitmap(hdc, 
-		&bi,				/* Pointer to BITMAPINFOHEADER */
-		CBM_INIT,			/* Initialize bitmap bits */
-		NULL,				/* Pointer to actual bitmap bits (if any) */
-		&binfo,				/* Pointer to BITMAPINFO */
-		DIB_RGB_COLORS);	/* Color usage */
+	hbmNew = CreateCompatibleBitmap(hdc, 
+		bi.biWidth,
+		bi.biHeight);
 #endif
 
     if (hbmNew == NULL) {

--- a/sim.h
+++ b/sim.h
@@ -8,6 +8,8 @@
 #include <windows.h>
 #include "sprite.h"
 
+#define OutputDebugString addDebugLog
+
 /* External declaration for UpdateToolbar function */
 extern void UpdateToolbar(void);
 


### PR DESCRIPTION
This enables VC2 build to work in NT 3.1 and make wintown startable in win32s (but main game screen is still black)